### PR TITLE
refactor: remove Hello World POC from bootstrap process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,6 @@ If `BOOTSTRAP.md` exists, follow it to establish your identity. During bootstrap
 2. **Fill in USER.md** (information about your human)
 3. **Set up your main board** (see below)
 4. **Register repos** (see below)
-5. **Run a "Hello World" POC** (see below)
 
 Then delete `BOOTSTRAP.md` — you won't need it again.
 
@@ -161,29 +160,6 @@ All your work should be **visible on a dedicated Agor board**. This ensures your
      ]
    }
    ```
-
----
-
-## "Hello World" POC
-
-After setting up your board and repos during bootstrap, demonstrate that Agor integration works:
-
-1. **Create a temporary worktree:**
-   - Use MCP tool: `agor_worktrees_create`
-   - Parameters: repoId (from configured repos), worktreeName='agor-claw-hello', createBranch=true, boardId (REQUIRED)
-   - Save the returned worktree_id
-
-2. **Create a session in the worktree:**
-   - Use MCP tool: `agor_sessions_create`
-   - Parameters: worktreeId (from step 1), agenticTool='claude-code', initialPrompt="Create a file called HELLO.md with a greeting"
-   - Save the returned session_id
-
-3. **Report to user:**
-   > "✅ POC complete! I created worktree `agor-claw-hello` (ID: [worktree_id]) and created session [session_id] to test the integration. You should see this on your board."
-
-4. **Track the POC:**
-   - Update today's daily log (memory/YYYY-MM-DD.md)
-   - Record: worktree_id, session_id, purpose="POC test", status="Success"
 
 ---
 


### PR DESCRIPTION
## Summary

Removes the "Hello World" POC section from the bootstrap process in AGENTS.md.

The POC step is redundant since the bootstrap session itself proves that Agor integration is working. This change simplifies the bootstrap process and prevents unnecessary complexity.

## Changes

- Removed the entire "Hello World POC" section (lines 167-188)
- Updated "First Run" section to remove POC reference (line 105)
- Bootstrap now consists of 4 steps instead of 5

## Rationale

The Hello World POC was problematic because:
1. It ran on the main branch, effectively starting a new "first boot" process
2. It created unnecessary complexity during bootstrap
3. The integration is already proven by the bootstrap session itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)