### PR TITLE
feat: add Agent Skills ecosystem awareness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,7 +421,11 @@ Use Agor's genealogy for complex work:
 
 ## Skills
 
-Skills are defined in the `skills/` directory. When you need to perform a complex operation, check if a skill exists:
+Skills follow the [SKILL.md standard](https://agentskills.io) — an open format supported by 30+ agent platforms.
+
+### Local Skills
+
+Custom skills live in the `skills/` directory:
 
 ```bash
 skills/
@@ -431,12 +435,20 @@ skills/
 └── testing/         # Test execution
 ```
 
-Each skill has a `SKILL.md` file with:
-- When to use
-- Prerequisites
-- Steps
-- Error handling
-- Related skills
+Each skill has a `SKILL.md` file with: when to use, prerequisites, steps, error handling, and related skills.
+
+### Community Skills Ecosystem
+
+A large ecosystem of community-built skills exists. Key platforms:
+- **[skills.sh](https://skills.sh)** — Curated, 83K+ skills, `npx skills add <owner/repo>`
+- **[SkillsMP](https://skillsmp.com)** — Largest catalog, 351K+ skills
+- **[anthropics/skills](https://github.com/anthropics/skills)** — Official Anthropic reference skills
+
+**When you recognize a repeating pattern**, check if a community skill exists before building custom. Suggest relevant skills to your human when patterns emerge.
+
+**Principle:** Prefer community skills for common patterns (linting, testing, deployment). Build custom for domain-specific needs (Agor workflows, org-specific processes).
+
+**Security:** Review SKILL.md source before installing. Prefer skills with high install counts from known publishers. See `skills/README.md` for detailed evaluation guidance.
 
 ---
 

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -132,6 +132,58 @@ Now set up your Agor workspace. This is where the magic happens.
 
 ---
 
+## Discover Skills
+
+Now that repos are set up, figure out what capabilities would be most useful.
+
+### Step 3: Explore the Agent Skills Ecosystem
+
+The [SKILL.md standard](https://agentskills.io) has become the universal format for agent capabilities, supported by 30+ platforms (Claude Code, Codex, Cursor, Copilot, and more). There are hundreds of thousands of community-built skills available.
+
+**Start a natural conversation:**
+
+> "What kinds of tasks will you be tackling most often? Code review, testing, deployments, documentation?"
+
+Based on their answer, introduce the ecosystem:
+
+> "There's a large ecosystem of community skills that might save us from reinventing the wheel. Want me to look into what's available for [their use cases]?"
+
+**If they're interested:**
+
+1. **Explain the main discovery platforms:**
+   - **[skills.sh](https://skills.sh)** — Curated catalog, ~83K+ skills, CLI install (`npx skills add <owner/repo>`). Best UX, tracks real install counts. Good signal-to-noise ratio.
+   - **[SkillsMP](https://skillsmp.com)** — Largest catalog (~351K+ skills), auto-crawls GitHub for SKILL.md files. More volume, less curation.
+   - **[agentskills.io](https://agentskills.io)** — Anthropic's official spec site and reference library. Trusted starting points.
+
+2. **Help them evaluate options:**
+   - Check install counts and community adoption
+   - Review the SKILL.md source before installing — it's just markdown, easy to audit
+   - Prefer skills from known organizations (e.g., `github.com/anthropics/skills`)
+   - Be aware of supply chain risk: community hubs have had malicious submissions
+
+3. **Install relevant skills:**
+   ```bash
+   npx skills add <owner/repo>
+   ```
+   Skills get added to the `.claude/` directory and are immediately available.
+
+4. **Record what was installed:**
+   Add to `IDENTITY.md`:
+   ```markdown
+   ## Installed Skills
+   - [skill-name] — [what it does] (source: [platform])
+   ```
+
+**If they prefer to build custom:**
+
+> "No problem. We can build exactly what you need in `skills/`. You can always tap into the ecosystem later."
+
+**If they're unsure:**
+
+> "Let's start without external skills. As we work together, I'll suggest community skills when I notice patterns that match. You can always say no."
+
+---
+
 ## Run a "Hello World" POC
 
 Time to prove Agor integration works!
@@ -282,6 +334,7 @@ Before deleting this file, make sure you've:
 - [ ] Set up main board in Agor
 - [ ] Filled in BOARD.md with board info and zones
 - [ ] Registered repos in `memory/agor-state/repos.json`
+- [ ] Discussed skills ecosystem and installed any relevant skills
 - [ ] Run POC (created worktree + session)
 - [ ] Created initial daily log (`memory/YYYY-MM-DD.md`)
 - [ ] Created Agor state tracking files (`memory/agor-state/`)

--- a/skills/README.md
+++ b/skills/README.md
@@ -170,15 +170,82 @@ Skills in this workspace should leverage Agor MCP heavily:
 
 ---
 
-## Future: Skill Discovery
+## The SKILL.md Standard
 
-As the agent learns and evolves, skills will:
-- Be created by the agent itself (self-improvement)
-- Be shared across agent instances
-- Evolve based on success/failure patterns
-- Become more automated over time
+The [SKILL.md format](https://agentskills.io) is an open standard (originated by Anthropic) for defining agent capabilities. It's supported by 30+ platforms including Claude Code, OpenAI Codex, Cursor, GitHub Copilot, VS Code, Gemini CLI, Kiro, JetBrains, and Roo Code.
 
-For now, start simple: document the patterns you want the agent to follow.
+A SKILL.md file is just markdown describing:
+- **When to use** the skill (trigger conditions)
+- **Prerequisites** (tools, permissions, context needed)
+- **Steps** to execute
+- **Error handling** and edge cases
+
+This is exactly the format used in this `skills/` directory. Skills you write here are compatible with the broader ecosystem.
+
+---
+
+## The Agent Skills Ecosystem
+
+A large ecosystem of community-built skills exists across several discovery platforms:
+
+### Discovery Platforms
+
+| Platform | Catalog Size | Strengths | Install Method |
+|----------|-------------|-----------|----------------|
+| [skills.sh](https://skills.sh) | 83K+ skills | Curated, best UX, real install counts, CLI-first | `npx skills add <owner/repo>` |
+| [SkillsMP](https://skillsmp.com) | 351K+ skills | Largest catalog, auto-crawls GitHub | Browse + manual install |
+| [agentskills.io](https://agentskills.io) | Reference library | Official Anthropic spec site, trusted starting points | Manual |
+
+### Installing Community Skills
+
+```bash
+# Install a skill from skills.sh
+npx skills add <owner/repo>
+
+# Skills are added to your .claude/ directory and immediately available
+```
+
+### Anthropic's Official Skills
+
+The [anthropics/skills](https://github.com/anthropics/skills) repository contains high-quality, trusted skills maintained by Anthropic. These are good starting points and reliable references for writing your own.
+
+### Evaluating Skill Quality and Security
+
+**Before installing any community skill:**
+
+1. **Read the SKILL.md source** — it's just markdown, easy to audit
+2. **Check install counts** on skills.sh (higher = more vetted by community)
+3. **Prefer known publishers** — official org repos, well-known maintainers
+4. **Review what it executes** — skills can run shell commands; understand what they do
+5. **Be cautious with low-install-count skills** from unknown authors
+
+**Security context:** Community hubs have had malicious skill submissions (341 flagged by Feb 2026). The SKILL.md format itself is safe (it's markdown), but skills that invoke shell commands or install dependencies need scrutiny. This is standard supply-chain hygiene — same as evaluating any open-source dependency.
+
+### When to Use Community Skills vs. Custom
+
+**Use community skills when:**
+- The task is a common pattern (linting, testing, deployment, code review)
+- A well-adopted skill exists (high install count, known publisher)
+- You want battle-tested workflows
+
+**Build custom skills when:**
+- The workflow is domain-specific to your repos or org
+- You need tight integration with Agor MCP operations
+- No community skill fits or existing ones need heavy modification
+- Security requirements demand full control
+
+**Principle:** Prefer community skills for common patterns, build custom for domain-specific needs.
+
+---
+
+## Skill Discovery as an Ongoing Practice
+
+As you work with your human, watch for repeating patterns:
+- Tasks that follow the same steps each time
+- Workflows the human describes verbally that could be codified
+- Pain points that a community skill might already solve
+
+When you spot a pattern, check the ecosystem first. If a good skill exists, suggest it. If not, create one in `skills/` and consider contributing it back.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **skills discovery step** (Step 3) to the bootstrap flow so new assistants naturally introduce the Agent Skills ecosystem during onboarding — with conversation prompts that adapt to user interest level
- Replaces the placeholder "Future: Skill Discovery" section in `skills/README.md` with comprehensive ecosystem documentation: the SKILL.md standard, three discovery platforms (skills.sh, SkillsMP, agentskills.io) with honest pros/cons, install workflow, and security evaluation guidance
- Updates the `AGENTS.md` Skills section with ecosystem awareness and the principle: prefer community skills for common patterns, build custom for domain-specific needs

## Key design decisions

- **Conversational, not prescriptive** — the bootstrap flow reads the user's interest before pushing skills. Three paths: interested → explore ecosystem, prefer custom → that's fine, unsure → defer and suggest later
- **Honest about tradeoffs** — no single platform is "the best"; security risks are acknowledged without fear-mongering
- **Proportional changes** — three files touched, existing voice and structure preserved

## Test plan

- [ ] Read through BOOTSTRAP.md and verify the skills discovery step flows naturally between repo setup and POC
- [ ] Verify skills/README.md ecosystem docs are accurate and the "Future" placeholder is gone
- [ ] Verify AGENTS.md Skills section references the ecosystem without being verbose
- [ ] Confirm no other files were unintentionally modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)