### PR TITLE
Document secure env var request flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,17 +106,13 @@ Don't memorize signatures — discover them. Always pass `boardId` when creating
 
 ### Secret / environment variable requests
 
-Assistants often need user-owned credentials while configuring MCP servers, skills, repository access, SaaS integrations, artifacts/proxies, or other workflows. **Never ask the user to paste secret values into chat.**
+When configuring MCPs, skills, repo access, SaaS integrations, artifacts/proxies, or other workflows, never ask users to paste secrets into chat. If a secret is missing, call `agor_widgets_request_env_vars` and end the turn.
 
-When a needed secret is missing, use `agor_widgets_request_env_vars`:
+- `names`: UPPER_SNAKE env var names only, 1–10 at a time, e.g. `GITHUB_TOKEN`, `HUBSPOT_API_KEY`.
+- `reason`: one short sentence (≤200 chars).
+- `auto_resume`: usually `true`.
 
-- Ask for env var **names only**, e.g. `GITHUB_TOKEN`, `HUBSPOT_API_KEY`, `DATADOG_API_KEY`.
-- Names must be UPPER_SNAKE; request 1–10 names at a time.
-- Provide one short `reason` sentence (≤200 chars) explaining why the value is needed.
-- Set `auto_resume: true` unless there is a specific reason not to.
-- The tool is fire-and-forget: call it, then end the turn. A later user/system-style message will say whether the user submitted or dismissed it.
-
-Secret values never enter agent context; only variable names do. Do not echo, print, log, commit, or store secret values. After submission, use the env var by name in commands/config (for example `$GITHUB_TOKEN`) and verify presence without printing values.
+Values never enter agent context; only names do. Do not echo, print, log, commit, or store secret values. After submission, use variables by name (for example `$GITHUB_TOKEN`) and verify presence without printing values.
 
 ### Knowledge + memory tools
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,20 @@ Agor MCP is assumed to be attached — it's the orchestration interface and self
 
 Don't memorize signatures — discover them. Always pass `boardId` when creating branches, or they'll be invisible on boards.
 
+### Secret / environment variable requests
+
+Assistants often need user-owned credentials while configuring MCP servers, skills, repository access, SaaS integrations, artifacts/proxies, or other workflows. **Never ask the user to paste secret values into chat.**
+
+When a needed secret is missing, use `agor_widgets_request_env_vars`:
+
+- Ask for env var **names only**, e.g. `GITHUB_TOKEN`, `HUBSPOT_API_KEY`, `DATADOG_API_KEY`.
+- Names must be UPPER_SNAKE; request 1–10 names at a time.
+- Provide one short `reason` sentence (≤200 chars) explaining why the value is needed.
+- Set `auto_resume: true` unless there is a specific reason not to.
+- The tool is fire-and-forget: call it, then end the turn. A later user/system-style message will say whether the user submitted or dismissed it.
+
+Secret values never enter agent context; only variable names do. Do not echo, print, log, commit, or store secret values. After submission, use the env var by name in commands/config (for example `$GITHUB_TOKEN`) and verify presence without printing values.
+
 ### Knowledge + memory tools
 
 Use the `knowledge` domain. Tool names may evolve; discover current signatures before calling.

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -73,6 +73,11 @@ Based on what they said, set up only what you need now:
 - Find or ask which board.
 - Record board ID, name, and URL in `IDENTITY.md` under `## Agor`.
 
+**Secrets / env vars for integrations** — when MCPs, skills, repos, SaaS APIs, artifacts, or proxies need tokens:
+- Do **not** ask the user to paste secret values into chat.
+- Request env var names with `agor_widgets_request_env_vars` (see `AGENTS.md` / `TOOLS.md`), then end the turn.
+- After submission, use variables by name (for example `$GITHUB_TOKEN`) and verify without printing values.
+
 **Repos they're working on:**
 - List Agor repos via current repo tools (Agor is the source of truth for IDs — don't cache them locally).
 - If a repo isn't in Agor yet, ask whether to set it up.

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -73,10 +73,7 @@ Based on what they said, set up only what you need now:
 - Find or ask which board.
 - Record board ID, name, and URL in `IDENTITY.md` under `## Agor`.
 
-**Secrets / env vars for integrations** — when MCPs, skills, repos, SaaS APIs, artifacts, or proxies need tokens:
-- Do **not** ask the user to paste secret values into chat.
-- Request env var names with `agor_widgets_request_env_vars` (see `AGENTS.md` / `TOOLS.md`), then end the turn.
-- After submission, use variables by name (for example `$GITHUB_TOKEN`) and verify without printing values.
+**Secrets / env vars for integrations** — if setup needs tokens, use `agor_widgets_request_env_vars`; don't ask for pasted values. See `AGENTS.md`.
 
 **Repos they're working on:**
 - List Agor repos via current repo tools (Agor is the source of truth for IDs — don't cache them locally).

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -80,18 +80,4 @@ Quick links to your most-used Knowledge skills and any bootstrap-critical local 
 
 ---
 
-## Requesting user secrets / env vars
-
-Use `agor_widgets_request_env_vars` instead of chat when configuration needs tokens:
-
-```text
-names: ["GITHUB_TOKEN"]
-reason: "Needed to configure GitHub access for this repo."
-auto_resume: true
-```
-
-Call via `agor_execute_tool`, then end the turn. See `AGENTS.md` for the security rules.
-
----
-
 For Agor MCP tool discovery, use `agor_search_tools` — don't inline tool signatures here. They'd just go stale.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -82,16 +82,15 @@ Quick links to your most-used Knowledge skills and any bootstrap-critical local 
 
 ## Requesting user secrets / env vars
 
-When configuration needs a user secret, use the Agor widget instead of chat:
+Use `agor_widgets_request_env_vars` instead of chat when configuration needs tokens:
 
 ```text
-agor_widgets_request_env_vars
-  names:       ["GITHUB_TOKEN"]     # UPPER_SNAKE, 1–10 names
-  reason:      "Needed to configure GitHub access for this repo."
-  auto_resume: true
+names: ["GITHUB_TOKEN"]
+reason: "Needed to configure GitHub access for this repo."
+auto_resume: true
 ```
 
-Call it via `agor_execute_tool`, then end the turn. Values never enter agent context; only names do. Use `$NAME` in commands/config and check that it exists without printing it.
+Call via `agor_execute_tool`, then end the turn. See `AGENTS.md` for the security rules.
 
 ---
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -80,4 +80,19 @@ Quick links to your most-used Knowledge skills and any bootstrap-critical local 
 
 ---
 
+## Requesting user secrets / env vars
+
+When configuration needs a user secret, use the Agor widget instead of chat:
+
+```text
+agor_widgets_request_env_vars
+  names:       ["GITHUB_TOKEN"]     # UPPER_SNAKE, 1–10 names
+  reason:      "Needed to configure GitHub access for this repo."
+  auto_resume: true
+```
+
+Call it via `agor_execute_tool`, then end the turn. Values never enter agent context; only names do. Use `$NAME` in commands/config and check that it exists without printing it.
+
+---
+
 For Agor MCP tool discovery, use `agor_search_tools` — don't inline tool signatures here. They'd just go stale.


### PR DESCRIPTION
## Summary
- Document `agor_widgets_request_env_vars` as the prescribed way to request user secrets/env vars
- Add onboarding/bootstrap guidance to avoid pasting secrets into chat
- Add a TOOLS.md shortcut for requesting env vars and using them safely by name

## Checks
- `git diff --check`
- markdown sanity script
