### PR TITLE
Add gateway channel setup skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ See `KNOWLEDGE.md` for the decision table, organization conventions, and MCP too
 | `BACKUP.md` | Git-backup model for the assistant home/base files |
 | `BOARD.md` | Your Agor board zones + workflow |
 | `TOOLS.md` | Env-specific shortcuts (incl. roster of repos you work in) |
-| `skills/` | Filesystem-backed skills, especially procedures with code/assets that need to execute locally; includes `skills/connect-saas.md` for SaaS/MCP tools |
+| `skills/` | Filesystem-backed skills, especially procedures with code/assets that need to execute locally; includes `skills/connect-saas.md` for SaaS/MCP tools and `skills/agor-gateway-channels.md` for inbound gateway channels |
 
 ---
 
@@ -110,7 +110,7 @@ Don't memorize signatures — discover them. Always pass `boardId` when creating
 
 ### Connecting SaaS / MCP tools
 
-Use `skills/connect-saas.md` whenever the user asks to connect an external service. It owns the detailed research, auth, session-attachment verification, and first-use checklist.
+Use `skills/connect-saas.md` whenever the user asks to connect an external service. It owns the detailed research, auth, session-attachment verification, and first-use checklist. Use `skills/agor-gateway-channels.md` when the user wants the assistant reachable from Slack/GitHub/Teams-style inbound channels.
 
 ### Secret / environment variable requests
 

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -86,7 +86,7 @@ Based on what they said, set up only what you need now:
 - Find or ask which board.
 - Record board ID, name, and URL in `IDENTITY.md` under `## Agor`.
 
-**SaaS / MCP tools** — use `skills/connect-saas.md`: research the best MCP/OAuth/skill path, explain expected effort, prefer existing Agor/company connector paths, and verify registered → enabled → attached to current session → authenticated → tools visible.
+**SaaS / MCP tools** — use `skills/connect-saas.md`: research the best MCP/OAuth/skill path, explain expected effort, prefer existing Agor/company connector paths, and verify registered → enabled → attached to current session → authenticated → tools visible. For inbound Slack/GitHub/Teams channels, use `skills/agor-gateway-channels.md`.
 
 **Secrets / env vars for integrations** — if setup needs tokens, use `agor_widgets_request_env_vars`; don't ask for pasted values. Show token type and minimum scopes before opening the widget. See `AGENTS.md`.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ On each fresh session, an assistant reads its core local files, then searches/re
 | `BOARD.md` | Agor board zones + workflow |
 | `HEARTBEAT.md` | Optional periodic tasks |
 | `TOOLS.md` | Env-specific shortcuts (incl. roster of repos) |
-| `skills/` | Local bootstrap/emergency procedures, including `connect-saas`; prefer Knowledge for evolving/shareable skills |
+| `skills/` | Local bootstrap/emergency procedures, including `connect-saas` and `agor-gateway-channels`; prefer Knowledge for evolving/shareable skills |
 
 ---
 
@@ -42,7 +42,7 @@ On each fresh session, an assistant reads its core local files, then searches/re
 
 - Ask and record the user’s security/sharing stance early: private vs trusted-team shared, and draft/read-only vs post/write after explicit approval.
 - First boot should greet the real user by name when known, lead with user value instead of internal files, avoid unexplained Agor jargon, and return clickable links for created artifacts.
-- For SaaS connections, use `skills/connect-saas.md`.
+- For SaaS connections, use `skills/connect-saas.md`; for inbound gateway channels, use `skills/agor-gateway-channels.md`.
 
 ## Knowledge-first defaults
 
@@ -98,3 +98,4 @@ Each assistant lives on its own branch. Git backs up the **assistant home/base f
 - **Agor:** [agor.live](https://agor.live)
 - **OpenClaw (inspiration):** [openclaw.ai](https://openclaw.ai)
 - **Connector skill:** [`skills/connect-saas.md`](skills/connect-saas.md)
+- **Gateway channel skill:** [`skills/agor-gateway-channels.md`](skills/agor-gateway-channels.md)

--- a/skills/README.md
+++ b/skills/README.md
@@ -34,7 +34,7 @@ Rule of thumb: instructions and references can live in Knowledge; executable ski
 - <common failure> → <fix>
 ```
 
-See `task-management.md` for a local worked example. Use `connect-saas.md` when connecting external SaaS/MCP tools; it is intentionally a research-and-wrapper method, not a catalog.
+See `task-management.md` for a local worked example. Use `connect-saas.md` when connecting external SaaS/MCP tools; it is intentionally a research-and-wrapper method, not a catalog. Use `agor-gateway-channels.md` for inbound Slack/GitHub/Teams-style gateway channels.
 
 ---
 

--- a/skills/agor-gateway-channels.md
+++ b/skills/agor-gateway-channels.md
@@ -1,0 +1,28 @@
+# Skill: agor-gateway-channels
+
+**When to use:** The user wants the assistant reachable from Slack, GitHub, Teams, or another gateway channel.
+
+**Goal:** Help open an approved inbound channel so users can tag/prompt the assistant where work already happens.
+
+## Model
+
+Gateway channels are incoming-first: they create Agor sessions from external messages/mentions. Do not assume they can proactively post scheduled outbound digests; use an outbound-capable SaaS connector for that.
+
+## Tools
+
+Discover schemas at runtime with `agor_search_tools` / `agor_get_tool_details` in the `gateway` domain. Current core tools:
+
+- `agor_gateway_channels_list` — find existing channels and IDs; secrets are redacted.
+- `agor_gateway_channels_create` — create a channel definition; current active connectors include Slack, GitHub, and Teams.
+- `agor_gateway_channels_update` — update/disable/rotate config; omit redacted secrets or pass `••••••••` to preserve them.
+
+These tools are admin-only. If permission is denied, give the user/admin the exact setup proposal instead of pretending it is done.
+
+## Steps
+
+1. Read `USER.md` for security stance and posting policy.
+2. Clarify: service, target branch, run-as Agor user if needed, allowed workspace/repo/channel scope, and whether replies may post or should draft/preview.
+3. List existing channels first; reuse/update approved company channels before creating new ones.
+4. Create/update with least privilege: require mentions where possible, restrict allowed channel IDs/repos, attach only needed MCP servers to gateway-created sessions.
+5. Never ask for pasted secrets. Prefer env/template references where supported; if a secret must be supplied, use the secure env-var widget path or hand off to an admin UI path.
+6. Verify with a minimal test mention/message, then return the channel/config link or ID and record the preference without secrets.


### PR DESCRIPTION
## Summary

- Add `skills/agor-gateway-channels.md`, a short skill for helping users/admins open inbound gateway channels.
- Point assistants to the new `gateway` MCP tools: `agor_gateway_channels_list`, `agor_gateway_channels_create`, and `agor_gateway_channels_update`.
- Add lightweight references from `AGENTS.md`, `BOOTSTRAP.md`, `README.md`, and `skills/README.md`.

## Notes

- Keeps the skill concise: agents should discover tool schemas at runtime.
- Clarifies gateway channels are incoming-first; scheduled outbound digests require an outbound-capable SaaS connector.
- Calls out admin-only tools and secret handling expectations.

## Validation

- `git diff --check`
