### PR TITLE
Harden SaaS and Slack onboarding skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -34,7 +34,7 @@ Rule of thumb: instructions and references can live in Knowledge; executable ski
 - <common failure> → <fix>
 ```
 
-See `task-management.md` for a local worked example. Use `connect-saas.md` when connecting external SaaS/MCP tools; it is intentionally a research-and-wrapper method, not a catalog. Use `agor-gateway-channels.md` for inbound Slack/GitHub/Teams-style gateway channels.
+See `task-management.md` for a local worked example. Use `connect-saas.md` when connecting external SaaS/MCP tools; it is intentionally a research-and-wrapper method, not a catalog. Use `connect-slack.md` for Slack-specific app/token/gateway prerequisites before requesting secrets. Use `agor-gateway-channels.md` for inbound Slack/GitHub/Teams-style gateway channels.
 
 ---
 

--- a/skills/agor-gateway-channels.md
+++ b/skills/agor-gateway-channels.md
@@ -8,6 +8,19 @@
 
 Gateway channels are incoming-first: they create Agor sessions from external messages/mentions. Do not assume they can proactively post scheduled outbound digests; use an outbound-capable SaaS connector for that.
 
+## Slack conversation semantics
+
+Document and configure Slack gateway channels around this intended model:
+
+- A top-level `@assistant` mention in an allowlisted channel starts a new Agor session on the target branch.
+- The assistant replies in the Slack thread for that mention.
+- The Slack thread is the session scope: `channel_id + thread_ts` maps to the Agor session, and follow-up thread replies continue that session.
+- New top-level mentions create new sessions.
+- Random channel messages should be ignored unless the gateway is explicitly configured otherwise.
+- Thread replies without another mention may be allowed only inside an existing mapped thread/session.
+
+If current product behavior does not thread replies or map sessions this way, note it as a gateway product issue and keep the skill documentation focused on the intended setup model.
+
 ## Tools
 
 Discover schemas at runtime with `agor_search_tools` / `agor_get_tool_details` in the `gateway` domain. Current core tools:

--- a/skills/connect-saas.md
+++ b/skills/connect-saas.md
@@ -10,7 +10,8 @@
 - Prefer reusable, approved paths over one-off secrets.
 - Ask/apply the user's security stance from `USER.md` when scopes, visibility, or posting are involved.
 - Never ask for secrets in chat; use `agor_widgets_request_env_vars`.
-- Verify: registered → enabled → attached to current session when needed → authenticated → tools visible → first useful action works.
+- Verify the full chain: public URL → OAuth discovery/DCR → register → enable → attach to current session when needed → authenticate → tools visible → first useful action works → fallback if blocked.
+- Be clear about scope words: **catalog/registry** means discoverable connection templates or candidates; **global/workspace MCP** means a reusable server registration in Agor; **session MCP** means attached to this conversation so tools can appear here. “No MCP servers attached” does not mean none exist in the catalog or workspace.
 
 ## Research order
 
@@ -19,6 +20,7 @@
 3. MCP server + Dynamic Client Registration (DCR).
 4. Trusted community skill.
 5. PAT/API token fallback with exact minimum scopes inline.
+6. Manual/export fallback if authentication or admin approval is blocked.
 
 Registry pointers, not a catalog:
 
@@ -26,18 +28,52 @@ Registry pointers, not a catalog:
 - MCP: [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io), [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers), [Smithery](https://smithery.ai), [Glama](https://glama.ai), [mcp.so](https://mcp.so), [PulseMCP](https://pulsemcp.com), [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers).
 - Meta-connectors: Zapier MCP, Composio, Pipedream.
 
-## Agor wrapper
+## Agor wrapper: full connection chain
 
-1. Discover exact Agor tool schemas at runtime (`mcp-servers`, service-specific tools, widgets).
-2. Find or create the non-secret config. For remote OAuth, start simple: `name` + public `url` + `auth:{type:"oauth"}`; add client/endpoints only if discovery/DCR fails.
-3. If session-scoped, attach it to the **current session**; don't stop at “registered.”
-4. Check auth status. If a token is unavoidable, explain token type + minimum scopes, call `agor_widgets_request_env_vars`, then stop.
-5. Verify tools are visible after refresh/re-prompt if needed.
-6. Do the first useful action, usually read/summarize/draft before write/post.
-7. Record outcome in memory/Knowledge if available; never record secrets.
+1. **Discover Agor tools at runtime.** Search `mcp-servers`, service-specific tools, widgets, and gateway tools as relevant; inspect schemas before execution.
+2. **Find the public connection URL.** Prefer a documented remote MCP URL or provider OAuth URL. If there is no public URL, use the best approved connector or API-token path.
+3. **Try OAuth discovery.** Register non-secret config first: `name` + public `url` + `auth:{type:"oauth"}` where supported. Let the server advertise metadata/endpoints when possible.
+4. **Use DCR when offered.** If discovery indicates Dynamic Client Registration, let Agor create/register a client rather than asking the user for client id/secret.
+5. **Register the MCP server in Agor.** This creates a reusable workspace/global config, not necessarily a tool in the current chat.
+6. **Enable it.** Disabled registrations may remain visible but should not be treated as usable.
+7. **Attach it to the current session when needed.** Do not stop at “registered.” Session attachment is what usually makes tools visible to this assistant turn/session.
+8. **Authenticate.** Send the user through OAuth or request env vars via the secure widget only after explaining token type and minimum scopes.
+9. **Verify.** Check registration state, enabled state, session attachment, auth state, and available tools. If tools are not visible, refresh/re-prompt or re-check attachment before concluding failure.
+10. **Prove value.** Do one small read-only useful action first; require explicit user buy-in before writes/posts.
+11. **Record outcome.** File memory/Knowledge if available; never store secret values.
+12. **Fallback.** If OAuth/admin/auth is blocked, offer manual/export/API-key alternatives with clear tradeoffs.
+
+## Redirect URI troubleshooting
+
+OAuth failures such as `invalid_request`, `redirect_uri_mismatch`, or “Mismatching redirect URI” usually mean the provider does not allow Agor's exact callback URL.
+
+Guide the user/admin to fix this **on the provider side**:
+
+1. Locate the exact Agor OAuth callback/redirect URI shown by the Agor MCP auth flow or error page.
+2. Open the provider's developer/admin settings for the app/client.
+3. Add that exact URI to the allowed redirect/callback URI list. Match scheme, host, path, and trailing slash exactly; test/self-hosted Agor URLs are often different from production.
+4. Save, reinstall/reauthorize if the provider requires it, then retry authentication.
+
+Example: for Fellow, an admin may need to allowlist the exact Agor callback URL in Fellow's admin/developer settings before `https://fellow.app/mcp` OAuth can complete. If the admin path is unavailable, move to fallback rather than burning time.
+
+## Manual/export fallback pattern
+
+When OAuth, DCR, app review, or admin approval blocks the ideal connector, make fallback a first-class move:
+
+1. State the blocker plainly and name the ideal path still preferred.
+2. Offer a bounded fallback that can produce value today without weakening security.
+3. Create or point to a small skill/procedure for repeated imports/exports if useful.
+4. Disable or pause noisy broken connector attempts when appropriate, and explain whether stale session attachments may still be visible.
+5. Keep the door open to return to the ideal connector later.
+
+Worked example: **Fellow manual export**
+
+- Ideal path: Fellow public MCP `https://fellow.app/mcp` with OAuth.
+- Common blocker: redirect URI mismatch or Fellow admin settings unavailable.
+- Fallback: ask the user to export/copy selected meeting notes, upload/place them in the agreed workbench or Knowledge location, then summarize/extract action items locally. If Fellow Developer API is available, request an API key via secure env var with minimum read scopes instead of raw chat paste.
 
 ## Examples
 
 - **GitHub:** Prefer existing GitHub MCP/App/OAuth. PAT fallback should be fine-grained, selected repos only, minimum permissions for the task.
-- **Fellow:** Try public MCP `https://fellow.app/mcp` with OAuth. Verify current-session attachment. Watch for redirect URI allowlisting on dev/test hosts.
-- **Slack:** Prefer an existing company Slack app/MCP if available. Proactive posts require an outbound-capable Slack connector and explicit posting policy.
+- **Fellow:** Try public MCP `https://fellow.app/mcp` with OAuth. Verify current-session attachment. Watch for redirect URI allowlisting on dev/test hosts. If blocked, use the manual/export fallback pattern.
+- **Slack:** Use `skills/connect-slack.md` for Slack-specific decisions, scopes, Socket Mode, event subscriptions, channel invite/ID, and `app_mention` test. Use `skills/agor-gateway-channels.md` for inbound mention gateway setup.

--- a/skills/connect-slack.md
+++ b/skills/connect-slack.md
@@ -1,0 +1,78 @@
+# Skill: connect-slack
+
+**When to use:** The user wants Slack connected to an assistant, either as a Slack MCP/tool connector or as an Agor gateway channel where people can mention the assistant.
+
+**Goal:** Guide Slack setup without opening a token widget too early. First choose ownership and app path; only request secrets after the user/admin understands prerequisites, scopes, and test criteria.
+
+## Start with the decision
+
+Before asking for tokens, present these options and ask which applies:
+
+1. **Reuse an existing Slack app** — best when the company already has an approved Agor/assistant bot. Needs a Slack app admin who can confirm scopes, Socket Mode, event subscriptions, and install/reinstall.
+2. **Create a new Slack app** — best for a pilot or isolated workspace/channel. Needs permission to create/install Slack apps and to generate bot/app tokens.
+3. **Invite a workspace admin** — best when the user lacks Slack admin/app permissions. Give the admin the exact checklist below; do not ask the user to paste secrets.
+
+Clarify who owns the connector:
+
+- **Private/user-owned:** tokens live in the user's env vars; other users may need their own setup.
+- **Shared/admin-owned:** a workspace/admin service identity owns the Slack app/tokens and gateway config; better for teams.
+- **Gateway config is not the same as secrets:** channel ID, target branch, mention policy, and session mapping may be shared; token values must stay out of chat/logs/docs.
+
+## Prerequisites checklist
+
+- Slack workspace where the app can be installed.
+- App admin or workspace admin available if the user cannot manage apps.
+- Target Agor branch/session behavior selected: which assistant/branch receives Slack mentions.
+- Target channel chosen; for private channels, the bot must be invited and private-channel scopes are required.
+- Posting policy from `USER.md`: read/draft only vs allowed to post replies in Slack.
+
+## Slack app requirements
+
+For Slack gateway/Socket Mode setup, verify or configure:
+
+1. **Socket Mode enabled.**
+2. **App-level token** with `connections:write` (`xapp-...`).
+3. **Bot token** (`xoxb-...`) after installing/reinstalling the app.
+4. **Bot OAuth scopes** minimum typical set:
+   - Public channels: `app_mentions:read`, `channels:read`, `channels:history`, `chat:write`, `users:read`.
+   - Private channels: also include `groups:read` and `groups:history` (or the specific `groups:*` scopes the gateway requires).
+   - Add broader scopes only when justified by the requested workflow.
+5. **Event subscriptions:** subscribe the bot to `app_mention`.
+6. **Install/reinstall** the app after scope/event changes.
+7. **Invite the bot** to the target channel, especially private channels.
+8. **Find the channel ID** (for example `C...`), not just the display name.
+
+## Secret handling
+
+Only after the checklist is understood and the user/admin agrees to proceed:
+
+- Request env vars with `agor_widgets_request_env_vars`; never ask for raw tokens in chat.
+- Typical names: `SLACK_BOT_TOKEN` for `xoxb-...`, `SLACK_APP_TOKEN` for `xapp-...`.
+- Include required scopes in the widget reason or surrounding explanation.
+- Stop after opening the widget; resume by verifying presence without printing values.
+
+## Agor gateway configuration
+
+Use `skills/agor-gateway-channels.md` for the Agor-side gateway steps. For Slack, the intended model is:
+
+- Top-level `@assistant` mention in an allowed channel starts a new Agor session.
+- Replies from the assistant should go in the Slack thread.
+- The Slack thread is the conversation/session scope; follow-up thread replies continue the same Agor session.
+- Random channel messages are ignored unless the gateway policy explicitly allows them.
+
+## Verification
+
+Run a minimal test before declaring success:
+
+1. Confirm gateway/channel is enabled and restricted to the intended channel ID.
+2. In Slack, post a top-level `@assistant` mention with a harmless prompt.
+3. Confirm Agor creates/routes a session on the target branch.
+4. Confirm the assistant reply appears in-thread and future thread replies stay in the same session.
+5. If the reply is not threaded, note it as a gateway product issue; do not try to fix product behavior in this skill.
+
+## If blocked
+
+- No Slack admin/app permission → ask the user to invite an admin and provide the checklist.
+- Bot cannot see a channel → invite the bot; for private channels confirm `groups:*` scopes and reinstall.
+- Tokens unavailable → pause Slack setup; offer a non-Slack first-value path (e.g. GitHub/Knowledge digest) while waiting.
+- OAuth/MCP path unavailable → use gateway setup if the ask is inbound mentions; use an outbound Slack connector only if proactive posting is required.


### PR DESCRIPTION
## Summary
- add a dedicated Slack connection skill that leads with reuse/create/admin decisioning before any token widget
- expand connect-saas with the full MCP setup chain, catalog/global/session wording, redirect URI troubleshooting, and manual/export fallback pattern
- document intended Slack gateway thread/session semantics and link the new Slack skill from skills README

## Notes
- Scope kept to framework skills only; product issues like redirect URI UI, Slack threading defaults, gateway secret templating, and context metrics are intentionally documented but not changed here.

## Test
- git diff --check